### PR TITLE
Added type attribute for script tag

### DIFF
--- a/src/app/design/frontend/base/default/layout/billsafe.xml
+++ b/src/app/design/frontend/base/default/layout/billsafe.xml
@@ -29,7 +29,7 @@
             <block type="core/text" name="billsafe_js">
                 <action method="setText">
                     <script>
-                    <![CDATA[<script src="https://content.billsafe.de/lpg/js/client.js"></script>]]>
+                    <![CDATA[<script type="text/javascript" src="https://content.billsafe.de/lpg/js/client.js"></script>]]>
                     </script>
                 </action>
             </block>


### PR DESCRIPTION
The type attribute was missing which resulted in an html error when validating the document.
